### PR TITLE
Python 3 support.

### DIFF
--- a/scrapoxy/commander.py
+++ b/scrapoxy/commander.py
@@ -13,7 +13,7 @@ class Commander:
 
     def __init__(self, api, password):
         self._api = api
-        self._password = base64.b64encode(password)
+        self._password = base64.b64encode(password.encode())
 
 
     def get_instances(self):

--- a/scrapoxy/downloadmiddlewares/proxy.py
+++ b/scrapoxy/downloadmiddlewares/proxy.py
@@ -21,7 +21,7 @@ class ProxyMiddleware(object):
             parts = re.match(r'(\w+://)(\w+:\w+@)?(.+)', proxy)
 
             if parts.group(2):
-                self._proxy_auth = u'Basic ' + base64.encodestring(parts.group(2)[:-1]).strip()
+                self._proxy_auth = u'Basic ' + base64.encodestring(parts.group(2)[:-1].encode()).decode().strip()
 
             self._proxy = parts.group(1) + parts.group(3)
 


### PR DESCRIPTION
This should fix https://github.com/fabienvauchelles/scrapoxy-python-api/issues/1 and work on Python 2 and 3 without any behavior changes.