### PR TITLE
Use the requests json() method to get the data from request

### DIFF
--- a/scrapoxy/commander.py
+++ b/scrapoxy/commander.py
@@ -13,7 +13,7 @@ class Commander:
 
     def __init__(self, api, password):
         self._api = api
-        self._password = base64.b64encode(password.encode())
+        self._password = base64.b64encode(password)
 
 
     def get_instances(self):
@@ -28,7 +28,7 @@ class Commander:
         r = requests.get(u'{0}/instances'.format(self._api), headers=headers)
 
         if r.status_code == 200:
-            return json.loads(r.content)
+            return r.json()
 
         else:
             r.raise_for_status()
@@ -54,7 +54,7 @@ class Commander:
             return -1
 
         elif r.status_code == 200:
-            result = json.loads(r.content)
+            result = r.json()
             return result['alive']
 
         else:
@@ -73,7 +73,7 @@ class Commander:
         r = requests.get(u'{0}/scaling'.format(self._api), headers=headers)
 
         if r.status_code == 200:
-            result = json.loads(r.content)
+            result = r.json()
             return result['min'], result['required'], result['max']
 
         else:
@@ -122,7 +122,7 @@ class Commander:
         r = requests.get(u'{0}/config'.format(self._api), headers=headers)
 
         if r.status_code == 200:
-            return json.loads(r.content)
+            return r.json()
 
         else:
             r.raise_for_status()


### PR DESCRIPTION
If I use the scrapoxy-python-api 1.9 with pyhton3.6 and scrapy 1.4.0 I get some errors in _commander.py_:

commander.py:16 AttributeError: 'bytes' object has no attribute 'encode'
I think the password is already in bytes so it is not necessary to encode it.

To avoid encode or decode problems (which I have with current version) in `json.loads(r.content)` you can use the request method `r.json()` which returns a json object.