### PR TITLE
Blacklist middleware ignore errors from Scrapoxy

### DIFF
--- a/scrapoxy/downloadmiddlewares/blacklist.py
+++ b/scrapoxy/downloadmiddlewares/blacklist.py
@@ -57,6 +57,9 @@ class BlacklistDownloaderMiddleware(object):
     def process_response(self, request, response, spider):
         """Detect blacklisted response and stop the instance if necessary.
         """
+        if 'x-cache-proxyname' not in response.headers:
+            return response
+        
         try:
             if response.status in self._http_status_codes:
                 raise BlacklistError(response, 'HTTP status {}'.format(response.status))


### PR DESCRIPTION
I was having problems when both Scrapoxy and the destination server could both return the same HTTP error code (e.g. 407).

If Scrapoxy sent a 407 error code then Blacklist was kicking in, even though it shouldn't, because the 407 wasn't from the destination server.